### PR TITLE
Currency parameter for balance and rank/leaderboard commands

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'sinatra'
 gem 'oauth2'
 gem 'coinbase'
 gem 'redis'
+gem 'money'
 
 group :development, :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,12 @@ GEM
       websocket-driver (>= 0.5.1)
     foreman (0.78.0)
       thor (~> 0.19.1)
+    i18n (0.7.0)
     json (1.8.3)
     jwt (1.5.2)
+    money (6.7.1)
+      i18n (>= 0.6.4, <= 0.7.0)
+      sixarm_ruby_unaccent (>= 1.1.1, < 2)
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -49,6 +53,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    sixarm_ruby_unaccent (1.1.1)
     slack-ruby-client (0.4.0)
       eventmachine
       faraday
@@ -67,6 +72,7 @@ PLATFORMS
 DEPENDENCIES
   coinbase
   foreman
+  money
   oauth2
   puma
   rack-test
@@ -76,5 +82,8 @@ DEPENDENCIES
   sinatra
   slack-ruby-client
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Tipping
 
 Other Commands
 
-  @tipbot balance                              # shows your balance, 'bal' also works
+  @tipbot balance <currency>                   # shows your balance, 'bal' also works
   @tipbot deposit                              # show a bitcoin address to add more funds
   @tipbot withdraw <amount> <address|email>    # withdraw to a bitcoin or email address
   @tipbot send <amount> <address|email>        # same as withdraw
-  @tipbot leaderboard                          # see who has what, 'rank' also works
+  @tipbot leaderboard <currency>               # see who has what, 'rank' also works
 
 In direct message chat, you can issue these commands without prefixing '@tipbot ...'.
 ```

--- a/commands.rb
+++ b/commands.rb
@@ -264,7 +264,7 @@ private
 
     raise ArgumentError.new("Unknown currency: #{currency}") if ratio.nil?
 
-    (btc_amount.to_f * ratio.to_f).round(8)
+    Money.from_amount(btc_amount.to_f * ratio.to_f, currency.upcase).format
   end
 
   def account_key team_domain, user_name

--- a/commands.rb
+++ b/commands.rb
@@ -14,11 +14,11 @@ Tipping
 
 Other Commands
 
-  @tipbot balance                              # shows your balance, 'bal' or 'b' also work
+  @tipbot balance <currency>                   # shows your balance, 'bal' or 'b' also work
   @tipbot deposit                              # show a bitcoin address to add more funds
   @tipbot withdraw <amount> <address|email>    # withdraw to a bitcoin or email address
   @tipbot send <amount> <address|email>        # same as withdraw
-  @tipbot leaderboard                          # see who has what, 'rank' also works
+  @tipbot leaderboard <currency>               # see who has what, 'rank' also works
 
 In direct message chat, you can issue these commands without prefixing '@tipbot ...'.```
 \n

--- a/initializers/money.rb
+++ b/initializers/money.rb
@@ -1,0 +1,2 @@
+require 'money'
+I18n.config.available_locales = :en


### PR DESCRIPTION
Added a currency parameter for the balance and rank/leaderboard commands using the coinbase exchange_rates API method.

Some users are unfamiliar with bitcoin and I figured they might use the bot more easily if they knew the fiat value first hand and didn't need to find a conversion calculator just to pay for a coffee.

Great bot by the way, thanks for it!
